### PR TITLE
Set name for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: build
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Setting a name for the `build` workflow in order to be able to set it as a "required check" in the repository settings.